### PR TITLE
Release v0.2.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ License
     :scale: 100%
     :target: https://calcifer.readthedocs.io/en/latest/?badge=latest
 
-.. |Version| image:: https://img.shields.io/pypi/v/calcifer.svg?maxAge=2592000
+.. |Version| image:: https://img.shields.io/pypi/v/calcifer.svg?maxAge=86400
    :target: https://pypi.python.org/pypi/calcifer
 
 .. |Status| image:: https://travis-ci.org/DramaFever/calcifer.svg?branch=master

--- a/calcifer/__init__.py
+++ b/calcifer/__init__.py
@@ -43,7 +43,7 @@ from calcifer.operators import (
 )
 from calcifer.partial import Partial
 from calcifer.monads import (
-    PolicyRule, PolicyRuleFunc
+    PolicyRule, PolicyRuleFunc, policy_rule, policy_rule_func,
 )
 from calcifer.policy import BasePolicy
 from calcifer.policy import DefaultPolicy as Policy

--- a/calcifer/_version.py
+++ b/calcifer/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 2, 0)
+version_info = (0, 2, 1)
 __version__ = '.'.join(str(v) for v in version_info[:3])

--- a/calcifer/operators.py
+++ b/calcifer/operators.py
@@ -10,9 +10,8 @@ from pymonad import List
 
 from calcifer.tree import PolicyNode
 from calcifer.monads import (
-    policy_rule_func, get_call_repr,
-
-    PolicyRule
+    policy_rule_funcM as policy_rule_func,
+    get_call_repr, PolicyRule
 )
 
 logger = logging.getLogger(__name__)

--- a/calcifer/tree.py
+++ b/calcifer/tree.py
@@ -124,7 +124,9 @@ class LeafPolicyNode(PolicyNode):
             logger.debug((
                 "Attempting to select sub-path %r of %r"
             ), path, self)
-            raise Exception("Node cannot be traversed")
+            raise Exception(
+                "Node cannot be traversed, attempted sub-path: {}".format(path)
+            )
 
         return (self, self)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -354,7 +354,7 @@ class PolicyBuilderTestCase(TestCase):
 
     def test_regarding_scoping(self):
         assertEqual = self.assertEqual
-        @policy_rule_func(List)
+        @policy_rule_func
         def expect_scope(expected="/", msg=None):
             def for_actual(actual):
                 def checker():


### PR DESCRIPTION
Change Log:

From #11:

- Allow Policy subclasses to define their own get_included_policy method to abstract how values are included via the `@Policy(includes=['other_policy_name'])` mechanism
- New `policy_rule` and `policy_rule_func` decorators
- Add more info to node traversal errors (ie, include the failed requested further traversal)