### PR TITLE
Abstract how policies include one another + other fixes

### DIFF
--- a/calcifer/__init__.py
+++ b/calcifer/__init__.py
@@ -43,7 +43,7 @@ from calcifer.operators import (
 )
 from calcifer.partial import Partial
 from calcifer.monads import (
-    PolicyRule, PolicyRuleFunc
+    PolicyRule, PolicyRuleFunc, policy_rule, policy_rule_func,
 )
 from calcifer.policy import BasePolicy
 from calcifer.policy import DefaultPolicy as Policy

--- a/calcifer/monads.py
+++ b/calcifer/monads.py
@@ -238,9 +238,30 @@ PolicyRule = BasePolicyRule
 PolicyRuleFunc = BasePolicyRuleFunc
 
 # decorators
-policy_rule = policyM(List)
+def policy_rule(*args, **kwargs):
+    """
+    Decorator to properly wrap a function of type
+        partial -> (value, partial')
+
+    ie., PolicyRule value
+
+    May be used with or without parentheses.
+    """
+
+    if len(args) == 1 and callable(args[0]):
+        return policyM(List)(args[0])
+    return policyM(List, *args, **kwargs)
 
 def policy_rule_func(*args, **kwargs):
+    """
+    Decorator to properly wrap a function of type
+        value -> PolicyRule value'
+
+    May be used with or without parentheses.
+
+    :param rule_func_name: Optional, to provide additional semantic information
+    about the policy rule function
+    """
     if len(args) == 1 and callable(args[0]):
         return policy_rule_funcM(List)(args[0])
     return policy_rule_funcM(List, *args, **kwargs)

--- a/calcifer/monads.py
+++ b/calcifer/monads.py
@@ -26,7 +26,7 @@ from abc import ABCMeta
 import copy
 import inspect
 import logging
-from pymonad import Monad
+from pymonad import Monad, List
 
 from calcifer import asts
 from calcifer.asts import get_call_repr # pylint: disable=unused-import
@@ -148,7 +148,7 @@ def policyM(m):
                 return self._bind_policy_rule(rule_func)
 
             if not isinstance(rule_func, BasePolicyRuleFunc):
-                rule_func = policy_rule_func(m)(rule_func)
+                rule_func = policy_rule_funcM(m)(rule_func)
 
             try:
                 binding = super(PolicyRule, self).bind(rule_func)
@@ -185,7 +185,7 @@ class BasePolicyRuleFunc:
     __metaclass__ = ABCMeta
 
 
-def policy_rule_func(m, rule_func_name=None):
+def policy_rule_funcM(m, rule_func_name=None):
     def decorator(rule_func):
         class PolicyRuleFunc(BasePolicyRuleFunc):
             def __init__(self, rule_func, rule_func_name=None):
@@ -236,3 +236,11 @@ def policy_rule_func(m, rule_func_name=None):
 
 PolicyRule = BasePolicyRule
 PolicyRuleFunc = BasePolicyRuleFunc
+
+# decorators
+policy_rule = policyM(List)
+
+def policy_rule_func(*args, **kwargs):
+    if len(args) == 1 and callable(args[0]):
+        return policy_rule_funcM(List)(args[0])
+    return policy_rule_funcM(List, *args, **kwargs)

--- a/calcifer/operators.py
+++ b/calcifer/operators.py
@@ -10,9 +10,8 @@ from pymonad import List
 
 from calcifer.tree import PolicyNode
 from calcifer.monads import (
-    policy_rule_func, get_call_repr,
-
-    PolicyRule
+    policy_rule_funcM as policy_rule_func,
+    get_call_repr, PolicyRule
 )
 
 logger = logging.getLogger(__name__)

--- a/calcifer/tree.py
+++ b/calcifer/tree.py
@@ -124,7 +124,9 @@ class LeafPolicyNode(PolicyNode):
             logger.debug((
                 "Attempting to select sub-path %r of %r"
             ), path, self)
-            raise Exception("Node cannot be traversed")
+            raise Exception(
+                "Node cannot be traversed, attempted sub-path: {}".format(path)
+            )
 
         return (self, self)
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -354,7 +354,7 @@ class PolicyBuilderTestCase(TestCase):
 
     def test_regarding_scoping(self):
         assertEqual = self.assertEqual
-        @policy_rule_func(List)
+        @policy_rule_func
         def expect_scope(expected="/", msg=None):
             def for_actual(actual):
                 def checker():


### PR DESCRIPTION
Mainly,

- Allow Policy subclasses to define their own `get_included_policy` method to abstract how values are included via the `@Policy(includes=['other_policy_name'])` mechanism
- New `policy_rule` and `policy_rule_func` decorators